### PR TITLE
Add missing release token

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -131,3 +131,4 @@ jobs:
           ~/auto shipit
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
In order to add GITHUB_TOKEN to the environment variables in the release workflow, this PR will:

- Update the release workflow configuration to include the GITHUB_TOKEN environment variable.